### PR TITLE
change grpc client codegen to user ClientConnInterface

### DIFF
--- a/protoc-gen-gogo/grpc/grpc.go
+++ b/protoc-gen-gogo/grpc/grpc.go
@@ -112,7 +112,7 @@ func (g *grpc) Generate(file *generator.FileDescriptor) {
 
 	g.P("// Reference imports to suppress errors if they are not otherwise used.")
 	g.P("var _ ", contextPkg, ".Context")
-	g.P("var _ ", grpcPkg, ".ClientConn")
+	g.P("var _ ", grpcPkg, ".ClientConnInterface")
 	g.P()
 
 	// Assert version compatibility.
@@ -172,7 +172,7 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 
 	// Client structure.
 	g.P("type ", unexport(servName), "Client struct {")
-	g.P("cc *", grpcPkg, ".ClientConn")
+	g.P("cc ", grpcPkg, ".ClientConnInterface")
 	g.P("}")
 	g.P()
 
@@ -180,7 +180,7 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 	if deprecated {
 		g.P(deprecationComment)
 	}
-	g.P("func New", servName, "Client (cc *", grpcPkg, ".ClientConn) ", servName, "Client {")
+	g.P("func New", servName, "Client (cc ", grpcPkg, ".ClientConnInterface) ", servName, "Client {")
 	g.P("return &", unexport(servName), "Client{cc}")
 	g.P("}")
 	g.P()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->
<!--- For ALL Contributors 👇 -->

## What was changed

Updating gogo code generation to generate client interceptors with the newer `grpc.ClientConnInterface` interface instead of the `*grpc.ClientConn` object.

## Why?

First, ClientConnInterface has become standard for go generated grpc code, gogo-protobuf is lagging behind.

Second, It is sometimes convenient to be able to implement this interface and use it in a client object, eg...

- testing.
- switching underlying conns based on call parameters.
- Custom conn pooling.

## Checklist

1. Closes <!-- add issue number here -->

2. How was this tested: We ran `protoc-gen-gogoslick` on the `temporalio/api-go` repository to regenerate code, and run the test given below.

3. Any docs updates needed? Probably not, this change generates code that is backwards compatible, and is standard for go generated code now.

### Test

To test we did the following
1. Install `protoc-gen-gogoslick` from source with these chance
2. run `make update-proto` in the temporalio/api-go repo
3. Add the following test file to temporalio/api-go and run it.

```go
package main_test

import (
	"context"
	"net"
	"testing"

	"github.com/gogo/status"
	"go.temporal.io/api/operatorservice/v1"
	"google.golang.org/grpc"
	"google.golang.org/grpc/codes"
	"google.golang.org/grpc/credentials/insecure"
)

func TestClientConnInterface(t *testing.T) {
	// in mem server to hit
	lis, err := net.Listen("tcp", "127.0.0.1:0")
	if err != nil {
		t.Fatal(err)
	}
	svr := grpc.NewServer()
	operatorservice.RegisterOperatorServiceServer(svr, &operatorservice.UnimplementedOperatorServiceServer{})

	// run it
	go func(lis net.Listener, svr *grpc.Server) {
		if err := svr.Serve(lis); err != nil {
			t.Log(err)
			t.Fail()
		}
	}(lis, svr)

	// dial it
	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
	if err != nil {
		t.Fatal(err)
	}
	client := operatorservice.NewOperatorServiceClient(conn)

	// call it, should return unimplemented, not some connection error.
	_, err = client.AddOrUpdateRemoteCluster(context.Background(), &operatorservice.AddOrUpdateRemoteClusterRequest{})
	if codes.Unimplemented != status.Code(err) {
		t.Errorf("unexpected status code %s", status.Code(err))
	}
}
```
